### PR TITLE
Add BigTop Hadoop Test Plan

### DIFF
--- a/test_plans/bigtop-processing-mapreduce
+++ b/test_plans/bigtop-processing-mapreduce
@@ -1,0 +1,6 @@
+bundle: bundle:~bigdata-dev/bigtop-processing-mapreduce
+benchmark:
+    resourcemanager:
+        terasort
+bundle_name: bigtop-processing-mapreduce
+bundle_file: bundle.yaml


### PR DESCRIPTION
Add Hadoop core processing bundle based off Apache BigTop for run in CWR. This test run also includes the terasort benchmark.