### PR TITLE
BigTop: Add URL comment

### DIFF
--- a/test_plans/bigtop-processing-mapreduce
+++ b/test_plans/bigtop-processing-mapreduce
@@ -1,3 +1,4 @@
+# Bundle info: https://jujucharms.com/u/bigdata-dev/bigtop-processing-mapreduce
 bundle: bundle:~bigdata-dev/bigtop-processing-mapreduce
 benchmark:
     resourcemanager:


### PR DESCRIPTION
Add comment with bundle file location. Longer term idea is to have a URL key in the test plan that also is presented on the report page.