### PR TITLE
only 1 benchmark is supported for now

### DIFF
--- a/test_plans/bigtop-processing-mapreduce.yaml
+++ b/test_plans/bigtop-processing-mapreduce.yaml
@@ -2,10 +2,6 @@
 bundle: bundle:~bigdata-dev/bigtop-processing-mapreduce
 benchmark:
     resourcemanager:
-        mrbench
-    resourcemanager:
-        nnbench
-    resourcemanager:
         terasort
 bundle_name: bigtop-processing-mapreduce
 bundle_file: bundle.yaml


### PR DESCRIPTION
Remove benchmarks from resourcemanager unit (currently, cwr only executes 1).  Add these back if/when https://github.com/juju-solutions/cloud-weather-report/issues/25 is fixed.