### PR TITLE
Remove and change test plans to get faster, passing runs

### DIFF
--- a/test_plans/apache-analytics-pig.yaml
+++ b/test_plans/apache-analytics-pig.yaml
@@ -1,6 +1,0 @@
-bundle: bundle:apache-analytics-pig
-benchmark:
-    resourcemanager:
-        terasort
-bundle_name: apache-analytics-pig
-bundle_file: bundle.yaml

--- a/test_plans/apache-analytics-sql.yaml
+++ b/test_plans/apache-analytics-sql.yaml
@@ -1,6 +1,0 @@
-bundle: bundle:apache-analytics-sql
-benchmark:
-    resourcemanager:
-        terasort
-bundle_name: apache-analytics-sql
-bundle_file: bundle.yaml

--- a/test_plans/apache-ingestion-kafka.yaml
+++ b/test_plans/apache-ingestion-kafka.yaml
@@ -1,6 +1,0 @@
-bundle: bundle:apache-ingestion-kafka
-benchmark:
-    resourcemanager:
-        terasort
-bundle_name: apache-ingestion-kafka
-bundle_file: bundle.yaml

--- a/test_plans/mediawiki-scalable.yaml
+++ b/test_plans/mediawiki-scalable.yaml
@@ -1,2 +1,0 @@
-bundle: bundle:mediawiki-scalable 
-bundle_name: mediawiki-scalable

--- a/test_plans/mongodb.yaml
+++ b/test_plans/mongodb.yaml
@@ -1,7 +1,0 @@
-bundle: cs:mongodb
-benchmark:
-    mongodb:
-        perf:
-            runtime: 60
-bundle_name: mongodb
-

--- a/test_plans/realtime-syslog-analytics.yaml
+++ b/test_plans/realtime-syslog-analytics.yaml
@@ -1,6 +1,0 @@
-bundle: bundle:realtime-syslog-analytics
-benchmark:
-    resourcemanager:
-        terasort
-bundle_name: realtime-syslog-analytics
-bundle_file: bundle.yaml

--- a/test_plans/wiki-simple.yaml
+++ b/test_plans/wiki-simple.yaml
@@ -1,0 +1,2 @@
+bundle: bundle:wiki-simple
+bundle_name: wiki-simple


### PR DESCRIPTION
Remove big data test plans other than hadoop-processing, and mongodb.  Change mediawiki-scalable to mediawiki-single.  This is to focus the runs on the bundles we most care about for now, bring the test run time down, and to get more passing builds.