### PR TITLE
Delete wiki-simple for mediawiki-single

### DIFF
--- a/test_plans/wiki-simple.yaml
+++ b/test_plans/wiki-simple.yaml
@@ -1,2 +1,0 @@
-bundle: bundle:wiki-simple
-bundle_name: wiki-simple


### PR DESCRIPTION
This bundle is intended to test the example bundle on jujucharms.com/get-started. However, that bundle is https://jujucharms.com/mediawiki-single/ not the current https://jujucharms.com/mediawiki-single/. This this pull is to remove wiki-simple. I will follow-up with an additional pull request to add in mediawiki-single