### PR TITLE
Add observable-kubernetes test plan

### DIFF
--- a/test_plans/observable-kubernetes
+++ b/test_plans/observable-kubernetes
@@ -1,0 +1,4 @@
+# Bundle info: https://jujucharms.com/observable-kubernetes
+bundle: bundle:observable-kubernetes
+bundle_name: observable-kubernetes
+bundle_file: bundle.yaml


### PR DESCRIPTION
Add observable-kubernetes bundle to the test plans for regular runs in CWR.