### PR TITLE
Delete observable-kubernetes

### DIFF
--- a/test_plans/observable-kubernetes.yaml
+++ b/test_plans/observable-kubernetes.yaml
@@ -1,4 +1,0 @@
-# Bundle info: https://jujucharms.com/observable-kubernetes
-bundle: bundle:observable-kubernetes
-bundle_name: observable-kubernetes
-bundle_file: bundle.yaml


### PR DESCRIPTION
This bundle has been superseded by https://jujucharms.com/canonical-kubernetes/