### PR TITLE
Remove docker test plan

### DIFF
--- a/test_plans/docker.yaml
+++ b/test_plans/docker.yaml
@@ -1,3 +1,0 @@
-bundle: cs:docker
-bundle_name: docker
-url: https://jujucharms.com/docker/


### PR DESCRIPTION
cs:docker is no longer maintained nor recommended.  The recommended workflow is to build charms based on layer-docker instead.  cs:docker is being put through the unmaintained process.