### PR TITLE
Add hadoop-spark bundle

### DIFF
--- a/test_plans/hadoop-spark.yaml
+++ b/test_plans/hadoop-spark.yaml
@@ -4,4 +4,4 @@ benchmark:
         nnbench
 bundle_name: hadoop-spark
 bundle_file: bundle.yaml
-https://jujucharms.com/hadoop-spark/
+url: https://jujucharms.com/hadoop-spark/

--- a/test_plans/hadoop-spark.yaml
+++ b/test_plans/hadoop-spark.yaml
@@ -1,0 +1,7 @@
+bundle: bundle:hadoop-spark
+benchmark:
+    resourcemanager:
+        nnbench
+bundle_name: hadoop-spark
+bundle_file: bundle.yaml
+https://jujucharms.com/hadoop-spark/


### PR DESCRIPTION
Add the hadoop-spark bundle to Canonical CWR test plans to run.