### PR TITLE
Add kafka-ingestion test plan

### DIFF
--- a/test_plans/kafka-ingestion.yaml
+++ b/test_plans/kafka-ingestion.yaml
@@ -1,0 +1,7 @@
+bundle: bundle:~bigdata-charmers/kafka-ingestion-1
+benchmark:
+    resourcemanager:
+        mrbench
+bundle_name: kafka-ingestion
+bundle_file: bundle.yaml
+url: https://jujucharms.com/u/bigdata-charmers/kafka-ingestion/1


### PR DESCRIPTION
Add the kafka ingestion bundle. This bundle is not yet recommended, but it is a bundle we are working on getting recommended and would like to start evaluating CWR test results. We will update the bundle once it is updated or recommended.