### PR TITLE
Add Mongo Charm

### DIFF
--- a/test_plans/mongodb.yaml
+++ b/test_plans/mongodb.yaml
@@ -1,0 +1,3 @@
+bundle: cs:~marcoceppi/mongodb
+bundle_name: mongodb
+url: https://jujucharms.com/u/marcoceppi/mongodb


### PR DESCRIPTION
Less the openstack-telemetry bundle the mongodb charm isn't used in any other recommended bundles. Thus adding the individual charm here for now to get CWR test results. We may need to create a bundle for this charm once development on it is complete to add replica sets. Until then the charm is in marcoceppi's name-space.