### PR TITLE
Added dense LXD test bundles

### DIFF
--- a/test_plans/ceph-with-dash-lxd.yaml
+++ b/test_plans/ceph-with-dash-lxd.yaml
@@ -1,0 +1,5 @@
+bundle: bundle:~juju-qa/ceph-with-dash
+bundle_name: ceph-with-dash-lxd
+bundle_file: ceph-with-dash-lxd.yaml
+test_label: orangebox-test
+url: https://jujucharms.com/u/juju-qa/ceph-with-dash

--- a/test_plans/hadoop-processing-lxd.yaml
+++ b/test_plans/hadoop-processing-lxd.yaml
@@ -1,0 +1,7 @@
+bundle: bundle:~/juju-qa/hadoop-processing
+benchmark:
+    resourcemanager:
+        terasort
+bundle_name: hadoop-processing-lxd
+bundle_file: hadoop-processing-lxd.yaml
+url: https://jujucharms.com/u/hadoop-processing-lxd/hadoop-processing

--- a/test_plans/hadoop-processing-lxd.yaml
+++ b/test_plans/hadoop-processing-lxd.yaml
@@ -4,4 +4,4 @@ benchmark:
         terasort
 bundle_name: hadoop-processing-lxd
 bundle_file: hadoop-processing-lxd.yaml
-url: https://jujucharms.com/u/hadoop-processing-lxd/hadoop-processing
+url: https://jujucharms.com/u/juju-qa/hadoop-processing

--- a/test_plans/hadoop-spark-lxd.yaml
+++ b/test_plans/hadoop-spark-lxd.yaml
@@ -1,0 +1,7 @@
+bundle: bundle:~/juju-qa/hadoop-spark
+benchmark:
+    resourcemanager:
+        nnbench
+bundle_name: hadoop-spark-lxd
+bundle_file: hadoop-spark-lxd.yaml
+url: https://jujucharms.com/u/juju-qa/hadoop-spark/

--- a/test_plans/kafka-ingestion-lxd.yaml
+++ b/test_plans/kafka-ingestion-lxd.yaml
@@ -1,0 +1,7 @@
+bundle: bundle:~juju-qa/kafka-ingestion
+benchmark:
+    resourcemanager:
+        mrbench
+bundle_name: kafka-ingestion-lxd
+bundle_file: kafka-ingestion-lxd.yaml
+url: https://jujucharms.com/u/juju-qa/kafka-ingestion

--- a/test_plans/spark-processing-lxd.yaml
+++ b/test_plans/spark-processing-lxd.yaml
@@ -1,0 +1,7 @@
+bundle: bundle:~juju-qa/spark-processing
+benchmark:
+    spark:
+        pagerank
+bundle_name: spark-processing-lxd
+bundle_file: spark-processing-lxd.yaml
+url: https://jujucharms.com/u/juju-qa/spark-processing/

--- a/test_plans/wiki-simple-lxd.yaml
+++ b/test_plans/wiki-simple-lxd.yaml
@@ -1,0 +1,4 @@
+bundle: bundle:~juju-qa/wiki-simple
+bundle_name: wiki-simple-lxd
+bundle_file: wiki-simple-lxd.yaml
+url: https://jujucharms.com/u/juju-qa/wiki-simple/

--- a/test_plans/wordpress-site-lxd.yaml
+++ b/test_plans/wordpress-site-lxd.yaml
@@ -1,0 +1,4 @@
+bundle: bundle:~juju-qa/wordpress-site
+bundle_name: wordpress-site-lxd
+bundle_file: wordpress-site-lxd.yaml
+url: https://jujucharms.com/u/juju-qa/wordpress-site


### PR DESCRIPTION
This branch adds dense LXD versions of bundles to the test plan. Only bundles that are LXD viable are added. Some tests are charms, or for kubernetes (which does not support lxd), or openstack (which requires special network considerations) are ignored.

For the tests I added, I forked the charm, added an extra bundle, and push+ publish-ed to the charmstrore. The charms claim to be stable. I cannot see them on https://jujucharms.com/ I cannot see all the bundles from the test plan either. I don't think that is an issue because I cloud use the charm command to get the bundles.

$ charm list -u juju-qa
cs:~juju-qa/bundle/ceph-with-dash-0
cs:~juju-qa/bundle/hadoop-processing-0
cs:~juju-qa/bundle/hadoop-spark-0
cs:~juju-qa/bundle/kafka-ingestion-0
cs:~juju-qa/bundle/spark-processing-0
cs:~juju-qa/bundle/wiki-simple-0
cs:~juju-qa/bundle/wordpress-site-0

I do not have a lot of confidence about the new bundles. Many existing bundles are tuned to use specific machines, implying that the charms are already maximising their hosts cpu, ram, and disk. My bundles specify large machines, but that does not mean the substrate has large enough machines, or that I guessed correctly about the constraints.

Tuning these bundles to pass may requires some expertise/development work to ensure enough resources are allocated. Several bundles might require several machines because the applications need more cpu, ram, or disk.