### PR TITLE
Added cwr options.

### DIFF
--- a/buildcloud/juju.py
+++ b/buildcloud/juju.py
@@ -42,7 +42,7 @@ class JujuClient:
                 run_command(
                     '{} bootstrap --show-log {} {} --config '
                     'test-mode=true --default-model {} --no-gui{}'.format(
-                            self.juju, controller, cloud, controller,
+                            self.juju, cloud, controller, controller,
                             args))
             except subprocess.CalledProcessError:
                 logging.error('Bootstrapping failed on {}'.format(

--- a/buildcloud/schedule_cwr_jobs.py
+++ b/buildcloud/schedule_cwr_jobs.py
@@ -62,6 +62,11 @@ def get_test_plans(args):
         yield test_plan
 
 
+def load_test_plan(test_plan):
+    with open(test_plan) as f:
+        return yaml.safe_load(f)
+
+
 def get_credentials(args):
     if None in (args.user, args.password):
         raise ValueError(
@@ -90,7 +95,11 @@ def build_jobs(credentials, test_plans, args):
     jenkins = Jenkins('http://juju-ci.vapour.ws:8080', *credentials)
     for test_plan in test_plans:
         test_id = generate_test_id()
-        for controller in args.controllers:
+        test_plan_content = load_test_plan(test_plan)
+        test_label = test_plan_content.get('test_label')
+        if test_label and isinstance(test_label, str):
+            test_label = [test_label]
+        for controller in test_label or args.controllers:
             job_name = get_job_name(controller)
             parameter = make_parameters(test_plan, args, controller, test_id)
             jenkins.build_job(job_name, parameter, token=args.cwr_test_token)

--- a/tests/test_build_cloud.py
+++ b/tests/test_build_cloud.py
@@ -2,7 +2,14 @@ import os
 from argparse import Namespace
 from unittest import TestCase
 
+from mock import (
+    Mock,
+    patch,
+)
+
 from buildcloud.build_cloud import (
+    get_cwr_options,
+    run_test_without_container,
     parse_args,
 )
 from tests.common_test import (
@@ -27,17 +34,67 @@ class TestCloudBuild(TestCase):
         os.environ['BUILD_NUMBER'] = "1234"
         args = parse_args(['cwr-model', 'test-plan'])
         expected = Namespace(bootstrap_constraints=None,
+                             bucket=None,
                              bundle_file='',
                              constraints='mem=3G',
+                             controllers=['cwr-model'],
+                             controllers_bootstrapped=False,
+                             cwr_path=None,
                              juju_home='/tmp/home/cloud-city',
                              juju_path='juju',
-                             no_container=False,
                              log_dir=None,
-                             controllers=['cwr-model'],
+                             no_container=False,
+                             results_dir=None,
+                             results_per_bundle=None,
+                             s3_creds=None,
+                             test_id='1234',
                              test_plan='test-plan',
-                             verbose=0, test_id="1234")
+                             verbose=0,
+                             )
         self.assertEqual(args, expected)
         os.environ['BUILD_NUMBER'] = build_number
 
     def get_args(self):
         return Namespace(env='juju-env')
+
+    def test_get_cwr_options(self):
+        args = parse_args(['controller', 'test-plan'])
+        host = Mock(test_results='/foo')
+        options = get_cwr_options(args, host)
+        expected = '--results-dir /foo --s3-private'
+        self.assertEqual(options, expected)
+
+        args = parse_args(['controller', 'test-plan',
+                           '--results-dir', 'foo/dir',
+                           '--bucket', 'bar',
+                           '--s3-creds', 'baz'])
+        options = get_cwr_options(args, host)
+        expected = ("--results-dir foo/dir --bucket bar --s3-creds baz "
+                    "--s3-private")
+        self.assertEqual(options, expected)
+
+    def test_run_test_without_container(self):
+        args = parse_args(['controller', 'test-plan', '--test-id', '2'])
+        with patch('buildcloud.build_cloud.run_command', autospec=True
+                   ) as rc_mock:
+            host = Mock(test_results='/test_results')
+            run_test_without_container(host, args, ['cntr1', 'cntr2'])
+        rc_mock.assert_called_once_with(
+            'cwr -F -l DEBUG -v  cntr1 cntr2 test-plan --test-id 2 '
+            '--results-dir /test_results --s3-private')
+
+    def test_run_test_without_container_non_default(self):
+        args = parse_args(['controller', 'test-plan',
+                           '--cwr-path', 'cwr/run.py',
+                           '--test-id', '2',
+                           '--results-dir', 'foo/dir',
+                           '--bucket', 'my-bucket',
+                           '--s3-creds', '/baz/creds'])
+        with patch('buildcloud.build_cloud.run_command', autospec=True
+                   ) as rc_mock:
+            host = Mock(test_results='/test_results')
+            run_test_without_container(host, args, ['cntr1', 'cntr2'])
+        rc_mock.assert_called_once_with(
+            'python cwr/run.py -F -l DEBUG -v  cntr1 cntr2 test-plan '
+            '--test-id 2 --results-dir foo/dir --bucket my-bucket --s3-creds '
+            '/baz/creds --s3-private')

--- a/tests/test_juju.py
+++ b/tests/test_juju.py
@@ -36,10 +36,10 @@ class TestJujuClient(TestCase):
         with patch('buildcloud.juju.run_command', autospec=True) as jrc_mock:
             jc._bootstrap()
         calls = ([
-            call('/foo/bar bootstrap --show-log gce google/europe-west1 '
+            call('/foo/bar bootstrap --show-log google/europe-west1 gce '
                  '--config test-mode=true --default-model gce --no-gui '
                  '--constraints mem=3G'),
-            call('/foo/bar bootstrap --show-log azure azure/westus --config '
+            call('/foo/bar bootstrap --show-log azure/westus azure --config '
                  'test-mode=true --default-model azure --no-gui '
                  '--constraints mem=3G')
         ])
@@ -56,10 +56,10 @@ class TestJujuClient(TestCase):
                    ) as jrc_mock:
             jc._bootstrap()
         calls = ([
-            call('/foo/bar bootstrap --show-log gce google/europe-west1 '
+            call('/foo/bar bootstrap --show-log google/europe-west1 gce '
                  '--config test-mode=true --default-model gce --no-gui '
                  '--constraints mem=3G'),
-            call('/foo/bar bootstrap --show-log azure azure/westus --config '
+            call('/foo/bar bootstrap --show-log azure/westus azure --config '
                  'test-mode=true --default-model azure --no-gui '
                  '--constraints mem=3G')
         ])
@@ -73,10 +73,10 @@ class TestJujuClient(TestCase):
         with patch('buildcloud.juju.run_command', autospec=True) as jrc_mock:
             jc._bootstrap()
         calls = ([
-            call('/foo/bar bootstrap --show-log gce google/europe-west1 '
+            call('/foo/bar bootstrap --show-log google/europe-west1 gce '
                  '--config test-mode=true --default-model gce --no-gui '
                  '--bootstrap-constraints tags=ob'),
-            call('/foo/bar bootstrap --show-log azure azure/westus --config '
+            call('/foo/bar bootstrap --show-log azure/westus azure --config '
                  'test-mode=true --default-model azure --no-gui '
                  '--bootstrap-constraints tags=ob')
         ])
@@ -93,10 +93,10 @@ class TestJujuClient(TestCase):
         with patch('buildcloud.juju.run_command', autospec=True) as jrc_mock:
             jc._bootstrap()
         calls = ([
-            call('/foo/bar bootstrap --show-log gce google/europe-west1 '
+            call('/foo/bar bootstrap --show-log google/europe-west1 gce '
                  '--config test-mode=true --default-model gce --no-gui '
                  '--constraints mem=2G --bootstrap-constraints tags=ob'),
-            call('/foo/bar bootstrap --show-log azure azure/westus --config '
+            call('/foo/bar bootstrap --show-log azure/westus azure --config '
                  'test-mode=true --default-model azure --no-gui '
                  '--constraints mem=2G --bootstrap-constraints tags=ob')
         ])
@@ -111,9 +111,9 @@ class TestJujuClient(TestCase):
         with patch('buildcloud.juju.run_command', autospec=True) as jrc_mock:
             jc._bootstrap()
         calls = ([
-            call('/foo/bar bootstrap --show-log gce google/europe-west1 '
+            call('/foo/bar bootstrap --show-log google/europe-west1 gce '
                  '--config test-mode=true --default-model gce --no-gui'),
-            call('/foo/bar bootstrap --show-log azure azure/westus --config '
+            call('/foo/bar bootstrap --show-log azure/westus azure --config '
                  'test-mode=true --default-model azure --no-gui')])
         self.assertEqual(jrc_mock.call_args_list, calls)
         self.assertEqual(jc.bootstrapped, ['gce', 'azure'])
@@ -131,9 +131,9 @@ class TestJujuClient(TestCase):
                         pass
         calls = ([
             call('/foo/bar/juju --version'),
-            call('/foo/bar/juju bootstrap --show-log gce google/europe-west1 '
+            call('/foo/bar/juju bootstrap --show-log google/europe-west1 gce '
                  '--config test-mode=true --default-model gce --no-gui'),
-            call('/foo/bar/juju bootstrap --show-log azure azure/westus '
+            call('/foo/bar/juju bootstrap --show-log azure/westus azure '
                  '--config test-mode=true --default-model azure --no-gui')])
         self.assertEqual(jrc_mock.call_args_list, calls)
         crl_mock.assert_called_once_with()
@@ -154,9 +154,9 @@ class TestJujuClient(TestCase):
                         pass
         calls = ([
             call('/foo/bar/juju --version'),
-            call('/foo/bar/juju bootstrap --show-log gce google/europe-west1 '
+            call('/foo/bar/juju bootstrap --show-log google/europe-west1 gce '
                  '--config test-mode=true --default-model gce --no-gui'),
-            call('/foo/bar/juju bootstrap --show-log azure azure/westus '
+            call('/foo/bar/juju bootstrap --show-log azure/westus azure '
                  '--config test-mode=true --default-model azure --no-gui')])
         self.assertEqual(jrc_mock.call_args_list, calls)
         crl_mock.assert_called_once_with()


### PR DESCRIPTION
- Added cwr options.
- Skip bootstrapping if the controller is already bootstrapped
- Added an option to run cwr from the source code by passing the path. This is used when needed to run cwr from the source rather than the released software. 
- Juju 2-ga bootstrap update
- Support restricting scheduling by test labels.