### PR TITLE
Delete ceph-with-dash.yaml

### DIFF
--- a/test_plans/ceph-with-dash.yaml
+++ b/test_plans/ceph-with-dash.yaml
@@ -1,4 +1,0 @@
-bundle: bundle:~canonical-storage/ceph-with-dash
-bundle_name: ceph-with-dash
-url: https://jujucharms.com/u/canonical-storage/ceph-with-dash
-


### PR DESCRIPTION
Remove this bundle and test plan for now while we develop a correct deployment method for AWS and Ceph Dash. This will be replaced with a ceph cluster bundle with no dash.