### PR TITLE
Delete percona-cluster.yaml

### DIFF
--- a/test_plans/percona-cluster.yaml
+++ b/test_plans/percona-cluster.yaml
@@ -1,3 +1,0 @@
-bundle: cs:percona-cluster
-bundle_name: percona-cluster
-url: https://jujucharms.com/percona-cluster/


### PR DESCRIPTION
Remove this charm test while we develop a bundle that doesn't relay on a VIP to be in place as this is difficult to determine via config across a set of clouds at any given run time.