### PR TITLE
Delete kubernetes-core.yaml

### DIFF
--- a/test_plans/kubernetes-core.yaml
+++ b/test_plans/kubernetes-core.yaml
@@ -1,4 +1,0 @@
-bundle: bundle:kubernetes-core
-bundle_name: kubernetes-core
-bundle_file: bundle.yaml
-url: https://jujucharms.com/kubernetes-core


### PR DESCRIPTION
Remove as these charms and solution context testing are being addressed in the canonical-kubernetes bundle.