### PR TITLE
use jujusolutions/cwrbox

### DIFF
--- a/buildcloud/build_cloud.py
+++ b/buildcloud/build_cloud.py
@@ -135,7 +135,7 @@ def env(args):
         container_repository = os.path.join(container_home, 'charm-repo')
         container_test_plans = os.path.join(container_home, 'test_plans')
         container = Container(user=container_user,
-                              name='seman/cwrbox',
+                              name='jujusolutions/cwrbox',
                               home=container_home,
                               ssh_home=container_ssh_home,
                               juju_home=container_juju_home,


### PR DESCRIPTION
cwrbox is moving to the `jujusolutions` namespace.  Once `jujusolutions/charmbox` has been registered in docker hub, switch build-cloud to use that image.